### PR TITLE
change the label Auditing

### DIFF
--- a/src/components/c/CollectionPermissions/index.jsx
+++ b/src/components/c/CollectionPermissions/index.jsx
@@ -69,7 +69,7 @@ export class CollectionPermissions extends PureComponent {
 					<AddButton className='add-course-button' type='submit' disabled={disabled}>Add</AddButton>
 				</form><br/>
 
-				<h4>TA / Faculty / Audit Exception</h4>
+				<h4>TA / Faculty / Auditing</h4>
 
 				<Search className='faculty-submit' onSubmit={handlers.addUser}>
 					<input className='faculty-input' type='search' placeholder={`Enter netID or name`} onChange={handlers.handleUserChange} value={username} />


### PR DESCRIPTION
Resolved issue #75
On collection permissions, change the label "Audit Exception" to "Auditing".