### PR TITLE
Fix TA permission issues

### DIFF
--- a/src/components/c/Collections/index.jsx
+++ b/src/components/c/Collections/index.jsx
@@ -25,6 +25,7 @@ export default class Collections extends PureComponent {
 			isMobile,
 			publicCollections,
 			searchQuery,
+			hasCollectionPermissions
 		} = this.props.viewstate
 
 		const {
@@ -94,7 +95,7 @@ export default class Collections extends PureComponent {
 				{!isMobile ?
 					<>
 						{
-							user !== null && user.roles < 3 ?
+							user !== null && (user.roles < 3 || hasCollectionPermissions) ?
 								<header className= 'collections-header'>
 									<div>
 										<h3>Public Collections &nbsp;&nbsp;&nbsp; </h3>

--- a/src/containers/c/CollectionsContainer.jsx
+++ b/src/containers/c/CollectionsContainer.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 
-import { collectionService, interfaceService, contentService } from 'services'
+import { collectionService, interfaceService, contentService, authService } from 'services'
 
 import { Collections } from 'components'
 
@@ -14,6 +14,8 @@ const CollectionsContainer = props => {
 
 	const {
 		user,
+		hasCollectionPermissions,
+		checkHasCollectionPermissions,
 		displayBlocks,
 		content,
 		setContent,
@@ -37,6 +39,7 @@ const CollectionsContainer = props => {
 		toggleTip()
 		getCollections()
 		setHeaderBorder(false)
+		checkHasCollectionPermissions(user.username)
 
 		// determine mobiie size for different layout
 		if(window.innerWidth < 1000) setIsMobile(true)
@@ -46,7 +49,7 @@ const CollectionsContainer = props => {
 			setHeaderBorder(true)
 			toggleTip(null)
 		}
-	}, [setContent, setHeaderBorder])
+	}, [setContent, setHeaderBorder, checkHasCollectionPermissions])
 
 	const handleShowHelp = () => {
 		toggleModal({
@@ -111,6 +114,7 @@ const CollectionsContainer = props => {
 		publicCollections: Object.entries(collections).filter(([k, v]) => v.public).map(([k,v]) => v),
 		contentIds: Object.entries(content).filter(([k, v]) => v.published).map(([k,v]) => k),
 		isMobile,
+		hasCollectionPermissions,
 		isContentTab,
 	}
 
@@ -131,12 +135,14 @@ const CollectionsContainer = props => {
 
 const mapStateToProps = ({ authStore, interfaceStore, collectionStore, contentStore }) => ({
 	user: authStore.user,
+	hasCollectionPermissions: authStore.hasCollectionPermissions,
 	displayBlocks: interfaceStore.displayBlocks,
 	collections: collectionStore.cache,
 	content: contentStore.cache,
 })
 
 const mapDispatchToProps = {
+	checkHasCollectionPermissions: authService.checkHasCollectionPermissions,
 	getCollections: collectionService.getCollections,
 	setContent: contentService.setContent,
 	toggleCollectionsDisplay: interfaceService.toggleCollectionsDisplay,

--- a/src/proxy/p/ApiProxy.js
+++ b/src/proxy/p/ApiProxy.js
@@ -563,6 +563,12 @@ const apiProxy = {
 				return error
 			}
 		},
+		getHasPermissions: async (username) => {
+			const res = await axios.get(`${process.env.REACT_APP_YVIDEO_SERVER}/api/user/${username}/ta-permissions`,{headers:{'Access-Control-Allow-Origin': `*`}}).then(async res => {
+				await updateSessionId(res.data[`session-id`])
+			})
+			return res.data
+		},
 		collections: {
 			/**
 			 * Retrieves the collections for the current user

--- a/src/services/s/auth.redux.js
+++ b/src/services/s/auth.redux.js
@@ -8,6 +8,7 @@ export default class AuthService {
 		AUTH_CLEAN: `AUTH_CLEAN`,
 		AUTH_ERROR: `AUTH_ERROR`,
 		AUTH_GET: `AUTH_GET`,
+		AUTH_HAS_COLLECTION_PERMISSIONS: `AUTH_HAS_COLLECTION_PERMISSIONS`,
 	}
 
 	// action creators
@@ -23,6 +24,10 @@ export default class AuthService {
 			type: this.types.AUTH_GET,
 			payload: { user },
 		}),
+		authHasCollectionPermissions: permissions => ({
+			type: this.types.AUTH_HAS_COLLECTION_PERMISSIONS,
+			payload: { permissions }
+		})
 	}
 
 	// default store
@@ -32,6 +37,7 @@ export default class AuthService {
 		loading: true,
 		message: ``,
 		tried: false,
+		permissions: false,
 	}
 
 	// reducer
@@ -77,6 +83,12 @@ export default class AuthService {
 				loading: payload,
 			}
 
+		case this.types.AUTH_HAS_COLLECTION_PERMISSIONS:
+			return{
+				...store,
+				permissions: payload.permissions,
+			}
+
 		default:
 			return store
 		}
@@ -103,6 +115,17 @@ export default class AuthService {
 		} catch (error) {
 			dispatch(this.actions.authError(error))
 		}
+	}
+
+	checkHasCollectionPermissions = (username) => (dispatch, { apiProxy }) => {
+			try {
+				const result = apiProxy.user.getHasPermissions(username)
+				// console.log('has collection permissions result: ', result)
+				dispatch(this.actions.authHasCollectionPermissions(result))
+			}
+			catch(error){
+				dispatch(this.actions.authError(error))
+			}
 	}
 
 	/**


### PR DESCRIPTION
Added changes so a TA can access the manage collections page as a stuydent. This is matching new logic for the back end, so this is breaking until the back-end is released for development #321 