### PR TITLE
The help modals' headers now act appropriately

### DIFF
--- a/src/components/c/Collections/styles.js
+++ b/src/components/c/Collections/styles.js
@@ -112,7 +112,7 @@ export const ViewToggle = styled.button`
 export const Help = styled.img`
 	width: 20px;
 	height: 20px;
-	margin-left: 20px;
+	margin-left: -5px;
 	position: relative;
 	bottom: -4px;
 `

--- a/src/components/modals/components/HelpDocumentation/index.jsx
+++ b/src/components/modals/components/HelpDocumentation/index.jsx
@@ -20,7 +20,7 @@ export default class HelpDocumentation extends PureComponent {
 					<Container id='help-documentation-container' onClick={e => {
 						e.stopPropagation()
 					}} onScroll={this.handleScroll}>
-						<h1>{name} <CloseHelp onClick={this.props.toggleModal}><img alt='' src={closeIcon} /></CloseHelp></h1>
+						<div style={{height: `50px`, width: `calc(80vw - 10px)`, backgroundColor: `white`, zIndex: `5`, position: `fixed`}}><h1>{name} <CloseHelp onClick={this.props.toggleModal}><img alt='' src={closeIcon} /></CloseHelp></h1></div>
 						<div id='content'>
 						</div>
 						{

--- a/src/components/modals/components/HelpDocumentation/index.jsx
+++ b/src/components/modals/components/HelpDocumentation/index.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 
-import { Container, Back, CloseHelp } from './styles'
+import { Container, Back, CloseHelp, Header } from './styles'
 
 import closeIcon from 'assets/x.svg'
 
@@ -20,7 +20,7 @@ export default class HelpDocumentation extends PureComponent {
 					<Container id='help-documentation-container' onClick={e => {
 						e.stopPropagation()
 					}} onScroll={this.handleScroll}>
-						<div style={{height: `50px`, width: `calc(80vw - 10px)`, backgroundColor: `white`, zIndex: `5`, position: `fixed`}}><h1>{name} <CloseHelp onClick={this.props.toggleModal}><img alt='' src={closeIcon} /></CloseHelp></h1></div>
+						<Header><h1>{name} <CloseHelp onClick={this.props.toggleModal}><img alt='' src={closeIcon} /></CloseHelp></h1></Header>
 						<div id='content'>
 						</div>
 						{

--- a/src/components/modals/components/HelpDocumentation/styles.js
+++ b/src/components/modals/components/HelpDocumentation/styles.js
@@ -44,14 +44,18 @@ export const Container = styled.div`
 	}
 
 	& h1 {
+		position: fixed;
 		border-bottom: 2px solid #0582ca;
 		padding-top: 5px;
 		height: 30px;
+		width: calc(80vw - 10px);
+		z-index: 3;
+		background-color: white;
 	}
 
 	& #content {
 		width: 80%;
-		margin: auto auto auto auto;
+		margin: 75px auto auto auto;
 		text-align: left;
 		position: relative;
 
@@ -165,8 +169,8 @@ export const CloseHelp = styled.span`
 		width: 30px;
 		height: 30px;
     position: absolute;
-    top: 10px;
-    right: 20px;
+    top: -4px;
+    right: 28px;
 	}
 	:hover {
 		cursor: pointer;

--- a/src/components/modals/components/HelpDocumentation/styles.js
+++ b/src/components/modals/components/HelpDocumentation/styles.js
@@ -177,5 +177,10 @@ export const CloseHelp = styled.span`
 	}
 `
 
-export const Tutorial = styled.div`
+export const Header = styled.div`
+	position: fixed;
+	height: 50px;
+	width: calc(80vw - 10px);
+	background-color: white;
+	z-index: 5;
 `

--- a/src/components/modals/containers/HelpDocumentationContainer.jsx
+++ b/src/components/modals/containers/HelpDocumentationContainer.jsx
@@ -371,10 +371,10 @@ const HelpDocumentationContainer = props => {
 					<h3>Resources</h3>
 					<p style="text-align: left; width: 100%;">
 						Y-video stores files in a server, and the same file can be used to create more than one content. <b>Resources let you upload files to create content</b>. You can learn to create a resource following
-						the video tutorial below
+						the video tutorial below.
 					</p>
 					<br/>
-					<label><b>Resource tips</b></label><br/>
+					<label><b>Resource tips:</b></label><br/>
 					<ul>
 						<li>The resource is a general placeholder for your files</li>
 						<li>A single resouce lets you upload files to work with different languages</li>


### PR DESCRIPTION
I changed the help modal's headers so that, when scrolling up and down, the headers and the close button remain visible the entire time.