### PR TITLE
Removed backend hits...

### DIFF
--- a/src/components/bits/AdminTable/index.jsx
+++ b/src/components/bits/AdminTable/index.jsx
@@ -18,7 +18,6 @@ const AdminTable = props => {
 		data,
 		mousePos,
 		isEdit,
-		collectionUsers,
 	} = props.viewstate
 
 	const {
@@ -27,7 +26,6 @@ const AdminTable = props => {
 		toggleMenu,
 		userRoleSave,
 		roleChange,
-		getUserFunc,
 	} = props.handlers
 
 	const {
@@ -36,12 +34,6 @@ const AdminTable = props => {
 	} = props.tipHandlers
 
 	const [sortOrder, setSortOrder] = useState({id: ``, reverse: false})
-
-	useEffect(() => {
-		if(searchCategory === `Collections`)
-			getUserFunc()
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [data])
 
 	if (!data.length || data[0] === undefined) return null
 
@@ -169,12 +161,16 @@ const AdminTable = props => {
 			return (
 				<>
 					<td>{item.name}</td>
-					<td>
-						{
-							`${collectionUsers?.[i] === `undefined` ? collectionUsers[i] : collectionUsers[i]?.name}
-							${collectionUsers?.[i] !== `undefined` ? `(${item.username})` : ``}`
-						}
-					</td>
+					{item[`account-name`] !== `` ?
+						<td>
+							{item[`account-name`]}
+							{` (${item.username})`}
+						</td>
+						:
+						<td>
+							undefined
+						</td>
+					}
 				</>
 			)
 		case `Content`:
@@ -313,43 +309,40 @@ const AdminTable = props => {
 	}
 
 	return (
-		searchCategory !== `Collections` || collectionUsers?.length === data?.length ?
-			<Style>
-				<Table>
-					<thead>
-						<tr>
-							{headers[searchCategory].columns.map((header, index) => <th className='headers' key={index}>{header.title}{header.filter && <Filter />}<Sort className='sorting-button' data-testid='sorting-button' onClick={() => sort(data, header.title)}/></th>)}
-							<th/>
-						</tr>
-					</thead>
-					<tbody>
-						{data.map(
-							(item, i) => <tr key={item.id}>
-								{ printTableValues(searchCategory, item, i) }
-								<td>
-									<ItemEdit
-										data-testid='item-edit'
-										onClick={toggleMenu(item.id)}
-										onMouseEnter={e => handleShowTip(`actions`,
-											{
-												x: e.target.getBoundingClientRect().x + 40,
-												y: e.target.getBoundingClientRect().y + 15,
-												width: e.currentTarget.offsetWidth + 20,
-											})
-										}
-										onMouseLeave={() => toggleTip()}
-									></ItemEdit>
-								</td>
-							</tr>,
-						)}
-					</tbody>
-				</Table>
-				{menuActive &&
-					<ItemMenu mousePos={mousePos} onMouseLeave={toggleMenu()}>{menuOptions(searchCategory, menuItemInfo)}</ItemMenu>
-				}
-			</Style>
-			:
-			null
+		<Style>
+			<Table>
+				<thead>
+					<tr>
+						{headers[searchCategory].columns.map((header, index) => <th className='headers' key={index}>{header.title}{header.filter && <Filter />}<Sort className='sorting-button' data-testid='sorting-button' onClick={() => sort(data, header.title)}/></th>)}
+						<th/>
+					</tr>
+				</thead>
+				<tbody>
+					{data.map(
+						(item, i) => <tr key={item.id}>
+							{ printTableValues(searchCategory, item, i) }
+							<td>
+								<ItemEdit
+									data-testid='item-edit'
+									onClick={toggleMenu(item.id)}
+									onMouseEnter={e => handleShowTip(`actions`,
+										{
+											x: e.target.getBoundingClientRect().x + 40,
+											y: e.target.getBoundingClientRect().y + 15,
+											width: e.currentTarget.offsetWidth + 20,
+										})
+									}
+									onMouseLeave={() => toggleTip()}
+								></ItemEdit>
+							</td>
+						</tr>,
+					)}
+				</tbody>
+			</Table>
+			{menuActive &&
+				<ItemMenu mousePos={mousePos} onMouseLeave={toggleMenu()}>{menuOptions(searchCategory, menuItemInfo)}</ItemMenu>
+			}
+		</Style>
 	)
 }
 

--- a/src/components/bits/AdminTable/index.jsx
+++ b/src/components/bits/AdminTable/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 
 import { Link } from 'react-router-dom'
 

--- a/src/containers/c/AdminContainer.jsx
+++ b/src/containers/c/AdminContainer.jsx
@@ -21,7 +21,6 @@ const AdminContainer = props => {
 		toggleTip,
 		adminUpdateUserRole,
 		setBreadcrumbs,
-		getUserById,
 	} = props
 
 	const category = {
@@ -42,7 +41,6 @@ const AdminContainer = props => {
 		},
 	}
 
-	const [collectionUsers, setCollectionUsers] = useState([])
 	const [searchQuery, setSearchQuery] = useState(``)
 	const [searchCategory, setSearchCategory] = useState(category.Users.name)
 	const [placeholder, setPlaceholder] = useState(category.Users.placeholder)
@@ -68,18 +66,6 @@ const AdminContainer = props => {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [setHeaderBorder])
-
-	const getUserFunc = async () => {
-		let temp = []
-		for( const item of data ) {
-			if(item.username !== ``) {
-				const user = await getUserById(item.owner)
-				temp = [...temp, user]
-			}else
-				temp = [...temp, `undefined`]
-		}
-		setCollectionUsers(temp)
-	}
 
 	const updateCategory = e => {
 		e.preventDefault()
@@ -164,11 +150,9 @@ const AdminContainer = props => {
 		mousePos,
 		isMobile,
 		isEdit,
-		collectionUsers,
 	}
 
 	const handlers = {
-		getUserFunc,
 		updateCategory,
 		updateSearchBar,
 		handleSubmit,
@@ -200,7 +184,6 @@ const mapDispatchToProps = {
 	toggleTip: interfaceService.toggleTip,
 	adminUpdateUserRole: adminService.updateUserRole,
 	setBreadcrumbs: interfaceService.setBreadcrumbs,
-	getUserById: adminService.getUserById,
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(AdminContainer)


### PR DESCRIPTION
Removed unnecessary backend hits, implemented new and complete object that contains both `account-name` and `netid`. Made the time that it takes to search for collections based on collection name a lot lower, and sort works correctly as both parts of the Owner section are now from the same object.